### PR TITLE
Add modular third example with tests

### DIFF
--- a/tests/test_combat.py
+++ b/tests/test_combat.py
@@ -1,0 +1,21 @@
+"""Tests for :mod:`third_example.combat`.
+
+The tests modify :data:`sys.path` so that the project root is available
+on the import path when tests are executed from within the ``tests``
+directory.
+"""
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from third_example.characters import Player, Monster
+from third_example import combat
+
+
+def test_attack_reduces_hp():
+    attacker = Player(name="Hero", hp=30, power=4)
+    defender = Monster(name="Orc", hp=10, power=3)
+    damage = combat.attack(attacker, defender)
+    assert damage == 4
+    assert defender.hp == 6

--- a/tests/test_map.py
+++ b/tests/test_map.py
@@ -1,0 +1,25 @@
+"""Tests for :mod:`third_example.map`.
+
+The tests modify :data:`sys.path` so that the project root is available
+on the import path when tests are executed from within the ``tests``
+directory.
+"""
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from third_example import map as map_module
+
+
+def test_create_map_dimensions():
+    game_map = map_module.create_map(5, 3)
+    assert len(game_map) == 3
+    assert all(len(row) == 5 for row in game_map)
+
+
+def test_is_blocked_detects_walls():
+    game_map = map_module.create_map(2, 2)
+    game_map[0][0] = "#"
+    assert map_module.is_blocked(0, 0, game_map)
+    assert not map_module.is_blocked(1, 1, game_map)

--- a/third_example/__init__.py
+++ b/third_example/__init__.py
@@ -1,0 +1,7 @@
+"""Third Example Game Package
+
+This package contains a simplified, modular rewrite of the original
+``second.py`` example.  Modules are split into map handling,
+character definitions, combat logic and item management to improve
+maintainability and readability.
+"""

--- a/third_example/characters.py
+++ b/third_example/characters.py
@@ -1,0 +1,41 @@
+"""Character definitions for the third example.
+
+The :class:`Character` class is intentionally lightweight and holds only
+attributes required for the accompanying unit tests.  Real games would
+include many more features such as inventory management and AI.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class Character:
+    """Basic game character.
+
+    Parameters
+    ----------
+    name:
+        Human readable identifier of the character.
+    hp:
+        Hit points representing the amount of damage the character can
+        withstand.
+    power:
+        Attack strength used in combat calculations.
+    """
+
+    name: str
+    hp: int
+    power: int
+
+    def take_damage(self, amount: int) -> None:
+        """Reduce :attr:`hp` by ``amount`` down to a minimum of zero."""
+        self.hp = max(0, self.hp - amount)
+
+
+class Player(Character):
+    """Player controlled character."""
+
+
+class Monster(Character):
+    """Non-player character used for combat demonstrations."""

--- a/third_example/combat.py
+++ b/third_example/combat.py
@@ -1,0 +1,16 @@
+"""Combat mechanics for the third example.
+
+The goal of this module is to demonstrate a very small combat system.
+Functions here operate on :class:`characters.Character` instances and
+adjust their hit points based on the attacker's power.
+"""
+from __future__ import annotations
+
+from .characters import Character
+
+
+def attack(attacker: Character, defender: Character) -> int:
+    """Apply damage from *attacker* to *defender* and return the damage dealt."""
+    damage = attacker.power
+    defender.take_damage(damage)
+    return damage

--- a/third_example/items.py
+++ b/third_example/items.py
@@ -1,0 +1,17 @@
+"""Item definitions used by the third example.
+
+Items are intentionally small and contain only the data needed for unit
+Tests.  They can be extended with additional behaviour such as being
+usable or equippable.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class Item:
+    """Simple item with a name and an optional power bonus."""
+
+    name: str
+    power_bonus: int = 0

--- a/third_example/map.py
+++ b/third_example/map.py
@@ -1,0 +1,40 @@
+"""Map creation and utilities.
+
+This module provides functions for creating a game map represented as
+simple two dimensional lists.  It intentionally keeps the feature set
+minimal so that it can be used as a teaching example for how to
+structure larger projects.
+"""
+from __future__ import annotations
+
+from typing import List
+
+Tile = str
+MapGrid = List[List[Tile]]
+
+
+def create_map(width: int, height: int, fill: Tile = ".") -> MapGrid:
+    """Return a new map filled with *fill* tiles.
+
+    Parameters
+    ----------
+    width, height:
+        Dimensions of the map to create.
+    fill:
+        Character used for all tiles.  The default is ``"."`` which
+        represents a walkable floor.
+    """
+    if width <= 0 or height <= 0:
+        raise ValueError("width and height must be positive")
+    return [[fill for _ in range(width)] for _ in range(height)]
+
+
+def is_blocked(x: int, y: int, game_map: MapGrid) -> bool:
+    """Return ``True`` if the tile at *x*, *y* is not walkable.
+
+    For this educational example every tile except ``'#'`` is walkable.
+    """
+    try:
+        return game_map[y][x] == "#"
+    except IndexError:
+        raise IndexError("coordinates out of bounds")

--- a/third_example/second.py
+++ b/third_example/second.py
@@ -1,0 +1,29 @@
+"""Entry point combining all modules of the third example.
+
+Running this module as a script will create a small map, instantiate a
+player and a monster and perform one attack so developers can see the
+modules interact.
+"""
+from __future__ import annotations
+
+from . import characters, combat, map as map_module
+
+
+def setup_demo():
+    """Create a demo map and two characters."""
+    game_map = map_module.create_map(10, 10)
+    player = characters.Player(name="Hero", hp=30, power=5)
+    monster = characters.Monster(name="Orc", hp=10, power=3)
+    return game_map, player, monster
+
+
+def main() -> None:
+    """Run a very small combat demonstration."""
+    _, player, monster = setup_demo()
+    damage = combat.attack(player, monster)
+    print(f"{player.name} attacks {monster.name} for {damage} hit points!")
+    print(f"{monster.name} has {monster.hp} HP left.")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual demonstration
+    main()


### PR DESCRIPTION
## Summary
- Rewrite `second.py` into a modular `third_example` package with separate map, character, combat and item modules
- Add an entry script demonstrating module interaction
- Provide unit tests for map generation and combat logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890b8669028832c897b9145492505b9